### PR TITLE
Font declarations should contain at least one generic font family

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -3,7 +3,7 @@
 @import "tailwindcss/components";
 
 body {
-  font-family: "Lato";
+  font-family: "Lato, sans-serif;";
   background-color: #f2f2f2;
 }
 
@@ -12,7 +12,7 @@ body {
 }
 
 .shadow-outline-red {
-	box-shadow: 0 0 0 3px rgba(255,0,0, 0.5);
+  box-shadow: 0 0 0 3px rgba(255, 0, 0, 0.5);
 }
 
 @import "tailwindcss/utilities";


### PR DESCRIPTION
If none of the font names defined in a font or font-family declaration are available on the browser of the user, the browser will display the text using its default font. It's recommended to always define a generic font family for each declaration of font or font-family to get a less degraded situation than relying on the default browser font. All browsers should implement a list of generic font matching these families: Serif, Sans-serif, cursive, fantasy, Monospace.